### PR TITLE
Update antares.md

### DIFF
--- a/_charas/antares.md
+++ b/_charas/antares.md
@@ -12,3 +12,7 @@ sidekicks:
 
 {% include voice-table.html resourceName="antares"
 %}
+
+## Notes
+
+- Despite not being (Seasonal) Variant unit, both Antares Hero and Sidekick units are only obtainable in banners where they are featured ; They are not available through regular Ether search nor through any other Seasonal banner.


### PR DESCRIPTION
Hello,
I'd like to add an additionnal note for all non (seasonal) variant characters that however have the same condition of availability.

Explain : It's only been until the return of the very first event banner recently that I noticed I never had Nessen sidekick popping during all my sessions (I had seen and pulled all other banner with limited regular characters and at least got the sidekick).

Only then, almost 1 year after starting the game, I took notice of the fact that, along even their 5* Hero unit, some Sidekick were banner limited. Since all the pull % list I ever read were some with 2 variants chars, I never really noticed the specificity due to the conditions I stated below.

As a result, I'd wish to add a note for any (new) player who would come to this Wiki to search intel on char (or simply check which one they'd like to have) to inform them whose characters cannot be obtained outside their featuring seasonal/campaign banner (or any other mixed banner where they are featured), so that they could plan ahead their Ether stones saving for when thoses banner are again available.

I'll only modify Antares for now so that the moderator who would have to check and confirm my addition :
- Can confirm to me my change is relevant and is accepted.
- Can be on the lookout for me adding the same note to all the others limited non variant char (Nessen, Giansar, Exio Anti-hero unit, Xeno Akashi,...).
- Can eventually modify my addition to meet standarts if my choice of words can be improved in case the change is accepted.

Thank you for reading.

GeoBlaze